### PR TITLE
Adding validate_certs in place of tower_verify_ssl for consistency in the Repo

### DIFF
--- a/roles/ansible_tower_genie_job_templates/README.md
+++ b/roles/ansible_tower_genie_job_templates/README.md
@@ -11,7 +11,7 @@ Currently:
 |Variable Name|Default Value|Required|Description|Example|
 |:---:|:---:|:---:|:---:|:---:|
 |`tower_hostname`|""|yes|URL to the Ansible Tower Server.|127.0.0.1|
-|`tower_verify_ssl`|`False`|no|Whether or not to validate the Ansible Tower Server's SSL certificate.||
+|`validate_certs`|`False`|no|Whether or not to validate the Ansible Tower Server's SSL certificate.||
 |`tower_username`|""|yes|Admin User on the Ansible Tower Server.||
 |`tower_password`|""|yes|Tower Admin User's password on the Ansible Tower Server.  This should be stored in an Ansible Vault at vars/tower-secrets.yml or elsewhere and called from a parent playbook.||
 |`tower_oauthtoken`|""|yes|Tower Admin User's token on the Ansible Tower Server.  This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook.||

--- a/roles/ansible_tower_genie_organizations/README.md
+++ b/roles/ansible_tower_genie_organizations/README.md
@@ -10,7 +10,7 @@ Currently:
 |Variable Name|Default Value|Required|Description|Example|
 |:---:|:---:|:---:|:---:|:---:|
 |`tower_hostname`|""|yes|URL to the Ansible Tower Server.|127.0.0.1|
-|`tower_verify_ssl`|`False`|no|Whether or not to validate the Ansible Tower Server's SSL certificate.||
+|`validate_certs`|`False`|no|Whether or not to validate the Ansible Tower Server's SSL certificate.||
 |`tower_username`|""|yes|Admin User on the Ansible Tower Server.||
 |`tower_password`|""|yes|Tower Admin User's password on the Ansible Tower Server.  This should be stored in an Ansible Vault at vars/tower-secrets.yml or elsewhere and called from a parent playbook.||
 |`tower_oauthtoken`|""|yes|Tower Admin User's token on the Ansible Tower Server.  This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook.||

--- a/roles/ansible_tower_genie_projects/README.md
+++ b/roles/ansible_tower_genie_projects/README.md
@@ -10,7 +10,7 @@ Currently:
 |Variable Name|Default Value|Required|Description|Example|
 |:---:|:---:|:---:|:---:|:---:|
 |`tower_hostname`|""|yes|URL to the Ansible Tower Server.|127.0.0.1|
-|`tower_verify_ssl`|`False`|no|Whether or not to validate the Ansible Tower Server's SSL certificate.||
+|`validate_certs`|`False`|no|Whether or not to validate the Ansible Tower Server's SSL certificate.||
 |`tower_username`|""|yes|Admin User on the Ansible Tower Server.||
 |`tower_password`|""|yes|Tower Admin User's password on the Ansible Tower Server.  This should be stored in an Ansible Vault at vars/tower-secrets.yml or elsewhere and called from a parent playbook.||
 |`tower_oauthtoken`|""|yes|Tower Admin User's token on the Ansible Tower Server.  This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook.||

--- a/roles/ansible_tower_genie_rbac/README.md
+++ b/roles/ansible_tower_genie_rbac/README.md
@@ -10,8 +10,8 @@ Currently:
 ## Variables
 |Variable Name|Default Value|Required|Description|Example|
 |:---:|:---:|:---:|:---:|:---:|
-|`tower_server`|""|yes|URL to the Ansible Tower Server.|127.0.0.1|
-|`tower_verify_ssl`|`False`|no|Whether or not to validate the Ansible Tower Server's SSL certificate.||
+|`tower_hostname`|""|yes|URL to the Ansible Tower Server.|127.0.0.1|
+|`validate_certs`|`False`|no|Whether or not to validate the Ansible Tower Server's SSL certificate.||
 |`tower_username`|""|yes|Admin User on the Ansible Tower Server.||
 |`tower_password`|""|yes|Tower Admin User's password on the Ansible Tower Server.  This should be stored in an Ansible Vault at vars/tower-secrets.yml or elsewhere and called from a parent playbook.||
 |`tower_oauthtoken`|""|yes|Tower Admin User's token on the Ansible Tower Server.  This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook.||
@@ -103,13 +103,13 @@ tower_rbac:
   tasks:
     - name: Get token for use during play
       uri:
-        url: "https://{{ tower_server }}/api/v2/tokens/"
+        url: "https://{{ tower_hostname }}/api/v2/tokens/"
         method: POST
         user: "{{ tower_username }}"
         password: "{{ tower_passname }}"
-        force_basic_auth: yes
+        force_basic_auth: true
         status_code: 201
-        validate_certs: no
+        validate_certs: false
       register: user_token
       no_log: True
 

--- a/roles/ansible_tower_genie_rbac/defaults/main.yml
+++ b/roles/ansible_tower_genie_rbac/defaults/main.yml
@@ -3,7 +3,7 @@ tower_hostname: ""
 tower_username: ""
 tower_password: "" #Put in a vault at vars/tower-secrets.yml when tower_secrets: true
 tower_oauthtoken: ""
-tower_validate_certs: false
+validate_certs: false
 tower_genie_rbac_secure_logging: "{{tower_genie_secure_logging | default(false)}}"
 
 tower_rbac:

--- a/roles/ansible_tower_genie_rbac/tasks/main.yml
+++ b/roles/ansible_tower_genie_rbac/tasks/main.yml
@@ -18,7 +18,7 @@
     tower_oauthtoken:               "{{ tower_oauthtoken | default(omit) }}"
     tower_host:                     "{{ tower_hostname }}"
     tower_config_file:              "{{ tower_config_file | default(omit) }}"
-    validate_certs:                 "{{ tower_validate_certs | default('omit') }}"
+    validate_certs:                 "{{ validate_certs | default('omit') }}"
   loop: "{{ tower_rbac }}"
   loop_control:
     loop_var: tower_rbac_item

--- a/roles/ansible_tower_genie_surveys/README.md
+++ b/roles/ansible_tower_genie_surveys/README.md
@@ -1,21 +1,24 @@
 # ansible_tower_genie_surveys
 ## Table of Contents
-- [Description](#description)
-- [Variables](#variables)
-	- [Variable `tower_surveys` Dictionary Specification](#variable-towersurveys-dictionary-specification)
-		- [`survey` Dictionary](#survey-dictionary)
-			- [Common Keys for `survey` Dictionaries](#common-keys-for-survey-dictionaries)
-			- [Type float Keys](#type-float-keys)
-			- [Type integer Keys](#type-integer-keys)
-			- [Type multiselect Keys](#type-multiselect-keys)
-			- [Type multiplechoice Keys](#type-multiplechoice-keys)
-			- [Type password Keys](#type-password-keys)
-			- [Type textarea Keys](#type-textarea-keys)
-			- [Type text Keys](#type-text-keys)
-- [Playbook Examples](#playbook-examples)
-	- [Normal Role Definition in Play](#normal-role-definition-in-play)
-	- [Import Role in Task](#import-role-in-task)
-- [Author](#author)
+- [ansible_tower_genie_surveys](#ansible_tower_genie_surveys)
+  - [Table of Contents](#table-of-contents)
+  - [Description](#description)
+  - [Variables](#variables)
+    - [Variable `tower_surveys` Dictionary Specification](#variable-tower_surveys-dictionary-specification)
+      - [`survey` Dictionary](#survey-dictionary)
+        - [Common Keys for `survey` Dictionaries](#common-keys-for-survey-dictionaries)
+        - [Type float Keys](#type-float-keys)
+        - [Type integer Keys](#type-integer-keys)
+        - [Type multiselect Keys](#type-multiselect-keys)
+        - [Type multiplechoice Keys](#type-multiplechoice-keys)
+        - [Type password Keys](#type-password-keys)
+        - [Type textarea Keys](#type-textarea-keys)
+        - [Type text Keys](#type-text-keys)
+  - [Playbook Examples](#playbook-examples)
+    - [Normal Role Definition in Play](#normal-role-definition-in-play)
+    - [Include Role in Task](#include-role-in-task)
+  - [License](#license)
+  - [Author](#author)
 
 ## Description
 An Ansible Role to deploy and ensure job template surveys are in a desired state in Ansible Tower.
@@ -23,7 +26,7 @@ An Ansible Role to deploy and ensure job template surveys are in a desired state
 |Variable Name|Default Value|Required|Description|Type|
 |---|:---:|:---:|---|:---:|
 |`tower_hostname`|""|yes|URL to the Ansible Tower Server.|string|
-|`tower_verify_ssl`|False|no|Whether or not to validate the Ansible Tower Server's SSL certificate.|boolean|
+|`validate_certs`|False|no|Whether or not to validate the Ansible Tower Server's SSL certificate.|boolean|
 |`tower_secrets`|False|yes|Whether or not to include variables stored in vars/tower-secrets.yml.  Set this value to `False` if you will be providing your sensitive values from elsewhere.|boolean|
 |`tower_username`|""|yes|Admin User on the Ansible Tower Server.|string|
 |`tower_password`|""|yes|Tower Admin User's password on the Ansible Tower Server.  This should be stored in an Ansible Vault at vars/tower-secrets.yml or elsewhere and called from a parent playbook.|string|
@@ -130,8 +133,8 @@ A field to enter text (string).
   roles:
     - role: "ansible_tower_genie_surveys"
       tower_hostname: "https://mytower.mydomain.com"
-      tower_verify_ssl: False
-      tower_secrets: False
+      validate_certs: false
+      tower_secrets: false
       tower_username: ""
       tower_password: "{{ vaulted_tower_pass }}"
       tower_surveys:
@@ -198,7 +201,7 @@ A field to enter text (string).
         name: "genie-survey"
       vars:
         tower_hostname: "https://mytower.mydomain.com"
-        tower_verify_ssl: False
+        validate_certs: false
         tower_secrets: False
         tower_username: ""
         tower_password: "{{ vaulted_tower_pass }}"

--- a/roles/ansible_tower_genie_surveys/defaults/main.yml
+++ b/roles/ansible_tower_genie_surveys/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 tower_hostname: ""
-tower_verify_ssl: false
+validate_certs: false
 tower_secrets: false
 tower_username: ""
 tower_password: "" #Put in a vault at vars/tower-secrets.yml when tower_secrets: True

--- a/roles/ansible_tower_genie_surveys/tasks/build_job_template_survey.yml
+++ b/roles/ansible_tower_genie_surveys/tasks/build_job_template_survey.yml
@@ -23,7 +23,7 @@
         force_basic_auth: True
         method: "GET"
         status_code: "200"
-        validate_certs: "{{ tower_verify_ssl }}"
+        validate_certs: "{{ validate_certs }}"
       register: "tower_job_templates"
       changed_when: false
       no_log: true
@@ -59,7 +59,7 @@
     force_basic_auth: True
     method: "GET"
     status_code: "200"
-    validate_certs: "{{ tower_verify_ssl }}"
+    validate_certs: "{{ validate_certs }}"
   register: "tower_job_template_current_survey"
   changed_when: false
   no_log: true
@@ -79,7 +79,7 @@
     body: "{{ tower_survey_formatted | to_json }}"
     body_format: "json"
     status_code: "200"
-    validate_certs: "{{ tower_verify_ssl }}"
+    validate_certs: "{{ validate_certs }}"
   register: "update_survey"
   changed_when: 'update_survey.status == 200'
   no_log: true
@@ -96,7 +96,7 @@
     body: '{"survey_enabled": true}'
     body_format: "json"
     status_code: "200"
-    validate_certs: "{{ tower_verify_ssl }}"
+    validate_certs: "{{ validate_certs }}"
   register: "enable_job_template_survey"
   changed_when: 'enable_job_template_survey.status == 200'
   no_log: true
@@ -115,7 +115,7 @@
     body: '{"survey_enabled": false}'
     body_format: "json"
     status_code: "200"
-    validate_certs: "{{ tower_verify_ssl }}"
+    validate_certs: "{{ validate_certs }}"
   register: "disable_job_template_survey"
   changed_when: 'disable_job_template_survey.status == 200'
   no_log: true

--- a/roles/ansible_tower_genie_teams/README.md
+++ b/roles/ansible_tower_genie_teams/README.md
@@ -5,7 +5,7 @@ An Ansible Role to create Teams in Ansible Tower.
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
 |`tower_hostname`|""|yes|URL to the Ansible Tower Server.|
-|`tower_verify_ssl`|False|no|Whether or not to validate the Ansible Tower Server's SSL certificate.|
+|`validate_certs`|False|no|Whether or not to validate the Ansible Tower Server's SSL certificate.|
 |`tower_secrets`|False|yes|Whether or not to include variables stored in vars/tower-secrets.yml.  Set this value to `False` if you will be providing the `tower_password` value from elsewhere.|
 |`tower_username`|""|yes|Admin User on the Ansible Tower Server.|
 |`tower_password`|""|yes|Tower Admin User's password on the Ansible Tower Server.  This should be stored in an Ansible Vault at vars/tower-secrets.yml or elsewhere and called from a parent playbook.|
@@ -20,7 +20,7 @@ An Ansible Role to create Teams in Ansible Tower.
   roles:
     - role: "genie-teams"
       tower_hostname: "https:/my-tower-server.foo.bar"
-      tower_verify_ssl: False
+      validate_certs: false
       tower_username: "admin"
       tower_password: "{{ my_tower_vault_pass }}"
       tower_org: "MY_ORG"
@@ -33,7 +33,7 @@ An Ansible Role to create Teams in Ansible Tower.
 - hosts: all
   vars:
     tower_hostname: "https://my-tower-server.foo.bar"
-    tower_verify_ssl: False
+    validate_certs: false
     tower_username: "admin"
     tower_password: "{{ my_tower_vault_pass }}"
     tower_org: "MY_ORG"

--- a/roles/ansible_tower_genie_teams/defaults/main.yml
+++ b/roles/ansible_tower_genie_teams/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
 tower_hostname: ""
 tower_username: ""
-tower_password: "" #Put in a vault at vars/tower-secrets.yml when tower_secrets: true
+tower_password: "" #Put in a vault at vars/tower-secrets.yml when tower_secrets: True
 tower_org: ""
-tower_verify_ssl: false
+validate_certs: false
 tower_team_name: ""
 tower_team_desc: ""
 tower_secrets: false

--- a/roles/ansible_tower_genie_teams/tasks/main.yml
+++ b/roles/ansible_tower_genie_teams/tasks/main.yml
@@ -9,5 +9,5 @@
     name: "{{ tower_team_name }}"
     description: "{{ tower_team_desc }}"
     organization: "{{ tower_org }}"
-    tower_verify_ssl: "{{ tower_verify_ssl }}"
+    validate_certs: "{{ validate_certs }}"
     state: "present"

--- a/roles/master_role_example/README.md
+++ b/roles/master_role_example/README.md
@@ -11,7 +11,7 @@ Currently:
 |Variable Name|Default Value|Required|Description|Example|
 |:---:|:---:|:---:|:---:|:---:|
 |`tower_hostname`|""|yes|URL to the Ansible Tower Server.|127.0.0.1|
-|`tower_verify_ssl`|`False`|no|Whether or not to validate the Ansible Tower Server's SSL certificate.||
+|`validate_certs`|`False`|no|Whether or not to validate the Ansible Tower Server's SSL certificate.||
 |`tower_username`|""|yes|Admin User on the Ansible Tower Server.||
 |`tower_password`|""|yes|Tower Admin User's password on the Ansible Tower Server.  This should be stored in an Ansible Vault at vars/tower-secrets.yml or elsewhere and called from a parent playbook.||
 |`tower_oauthtoken`|""|yes|Tower Admin User's token on the Ansible Tower Server.  This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook.||

--- a/roles/tower_inventories/README.md
+++ b/roles/tower_inventories/README.md
@@ -6,7 +6,7 @@ An Ansible role to create inventories.
 | Variable Name | Default Value | Required | Description | Type |
 |---|---|:---:|---|:---:|
 |`tower_hostname`|""|yes|URL to the Ansible Tower Server.| string |
-|`tower_verify_ssl`|False|no|Whether or not to validate the Ansible Tower Server's SSL certificate.| boolean |
+|`validate_certs`|False|no|Whether or not to validate the Ansible Tower Server's SSL certificate.| boolean |
 |`tower_secrets`|False|yes|Whether or not to include variables stored in vars/tower-secrets.yml.  Set this value to `False` if you will be providing your sensitive values from elsewhere.| boolean |
 |`tower_username`|""|yes|Admin User on the Ansible Tower Server.| boolean |
 |`tower_password`|""|yes|Tower Admin User's password on the Ansible Tower Server.  This should be stored in an Ansible Vault at vars/tower-secrets.yml or elsewhere and called from a parent playbook.| boolean |

--- a/roles/tower_inventory_sources/defaults/main.yml
+++ b/roles/tower_inventory_sources/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 tower_hostname: ""
-tower_verify_ssl: False
+validate_certs: False
 tower_secrets: False
 tower_username: ""

--- a/roles/tower_inventory_sources/tasks/main.yml
+++ b/roles/tower_inventory_sources/tasks/main.yml
@@ -26,7 +26,7 @@
     tower_username:              "{{ tower_username | default(omit) }}"
     tower_password:              "{{ tower_password | default(omit) }}"
     tower_oauthtoken:            "{{ tower_oauthtoken | default(omit) }}"
-    validate_certs:              "{{ tower_verify_ssl | default('false') }}"
+    validate_certs:              "{{ validate_certs | default('false') }}"
   loop: "{{ tower_inventory_sources }}"
   loop_control:
     loop_var: source


### PR DESCRIPTION
## Purpose

- I believe we have inconsistencies in the repo with `validate_certs` vs `tower_verify_ssl`. I chose to use `validate_certs` as the official auth docs say `validate_certs` is name of the argument while `tower_verify_ssl` is an alias.

Creating independent PRs for easier reviews. 
To be merged in numeric order number of the PRs.