### PR TITLE
Improvements to demo playbook

### DIFF
--- a/playbooks/example_with_yaml/configure_tower.yml
+++ b/playbooks/example_with_yaml/configure_tower.yml
@@ -12,17 +12,19 @@
         dir: ./tower_configs
         ignore_files: [tower_config.yml.template]
         extensions: ["yml"]
+      tags:
+        - always
   roles:
-    - {role: tower_settings, when: tower_settings is defined}
-    - {role: organizations, when: tower_organizations is defined}
-    - {role: users, when: tower_user_accounts is defined}
-    - {role: teams, when: tower_teams is defined}
-    - {role: credentials, when: tower_credentials is defined}
-    - {role: inventories, when: tower_inventories is defined}
-    - {role: projects, when: tower_projects is defined}
-    - {role: inventory_sources, when: tower_inventory_sources is defined}
-    - {role: hosts, when: tower_hosts is defined}
-    - {role: job_templates, when: tower_templates is defined}
-    - {role: schedules, when: tower_schedules is defined}
-    - {role: notifications, when: tower_notifications is defined}
-    - {role: tower_role, when: tower_rbac is defined}
+    - {role: tower_settings, when: tower_settings is defined, tags: tower_settings}
+    - {role: organizations, when: tower_organizations is defined, tags: organizations}
+    - {role: users, when: tower_user_accounts is defined, tags: users}
+    - {role: teams, when: tower_teams is defined, tags: teams}
+    - {role: credentials, when: tower_credentials is defined, tags: credentials}
+    - {role: inventories, when: tower_inventories is defined, tags: inventories}
+    - {role: projects, when: tower_projects is defined, tags: projects}
+    - {role: inventory_sources, when: tower_inventory_sources is defined, tags: inventory_sources}
+    - {role: hosts, when: tower_hosts is defined, tags: hosts}
+    - {role: job_templates, when: tower_templates is defined, tags: job_templates}
+    - {role: schedules, when: tower_schedules is defined, tags: schedules}
+    - {role: notifications, when: tower_notifications is defined, tags: notifications}
+    - {role: tower_role, when: tower_rbac is defined, tags: tower_role}

--- a/playbooks/example_with_yaml/tower_configs/tower_credentials.yml
+++ b/playbooks/example_with_yaml/tower_configs/tower_credentials.yml
@@ -1,6 +1,13 @@
 ---
 # Commented out content is serving as example for you to add new content.
 tower_credentials:
+  - kind: ssh
+    organization: Default
+    name: Demo Credential
+    description: A Demo Credential
+    inputs:
+      username: username
+      password: password
   - kind: rhv
     name: admin@internal-RHVM-01
     description: infra-rhvm-01 creds for inventory sources.

--- a/playbooks/example_with_yaml/tower_configs/tower_hosts.yml
+++ b/playbooks/example_with_yaml/tower_configs/tower_hosts.yml
@@ -5,3 +5,4 @@ tower_hosts:
     state: present
     variables:
       some_var: some_val
+      ansible_connection: local

--- a/playbooks/example_with_yaml/tower_configs/tower_inventory_sources.yml
+++ b/playbooks/example_with_yaml/tower_configs/tower_inventory_sources.yml
@@ -8,4 +8,4 @@ tower_inventory_sources:
     overwrite: true
     update_on_launch: true
     update_cache_timeout: 0
-  # more options can be provided but for RHV source we are using, we need only this much.
+    # more options can be provided but for RHV source we are using, we need only this much.

--- a/playbooks/example_with_yaml/tower_configs/tower_notifications.yml
+++ b/playbooks/example_with_yaml/tower_configs/tower_notifications.yml
@@ -19,6 +19,6 @@ tower_notifications:
       - admin@example.com
     sender: tower0@example.com
     port: 25
-    username: '' # this is required even if there's no username
-    password: '' # this is required even if there's no password
+    username: ''  # this is required even if there's no username
+    password: ''  # this is required even if there's no password
     state: present

--- a/playbooks/example_with_yaml/tower_configs/tower_organizations.yml
+++ b/playbooks/example_with_yaml/tower_configs/tower_organizations.yml
@@ -1,6 +1,6 @@
 ---
 tower_organizations:
   - name: Satellite
-    state: present # optional
+    state: present  # optional
   - name: Default
     state: present

--- a/playbooks/example_with_yaml/tower_configs/tower_rbac.yml
+++ b/playbooks/example_with_yaml/tower_configs/tower_rbac.yml
@@ -1,3 +1,4 @@
+---
 tower_rbac:
   - inventory:  RHVM-01
     team: satlab-admin

--- a/playbooks/example_with_yaml/tower_configs/tower_user_accounts.yml
+++ b/playbooks/example_with_yaml/tower_configs/tower_user_accounts.yml
@@ -1,5 +1,5 @@
 ---
 tower_user_accounts:
   - user: tower_user
-    superuser: no
+    superuser: false
     password: tower_password


### PR DESCRIPTION
I've done some improvements to the demo playbook to allow running e2e for test purposes from a blank dataset (including getting rid of reliance on demo data)

- Allows full e2e run from DB with no data
- Adds tags example to include only specific sections
- Fixes some lint warnings