### PR TITLE
Add option to set state of all objects as a default

### DIFF
--- a/playbooks/example_with_yaml/tower_configs/tower_hosts.yml
+++ b/playbooks/example_with_yaml/tower_configs/tower_hosts.yml
@@ -2,6 +2,5 @@
 tower_hosts:
   - name: localhost
     inventory: localhost
-    state: present
     variables:
       some_var: some_val

--- a/playbooks/example_with_yaml/tower_configs/tower_inventories.yml
+++ b/playbooks/example_with_yaml/tower_configs/tower_inventories.yml
@@ -10,14 +10,11 @@ tower_inventories:
   - name: RHVM-01
     organization: Satellite
     description: created by Ansible Playbook - for RHVM-01
-    state: present
   - name: RHVM-02
     organization: Satellite
     description: created by Ansible Playbook - for RHVM-02
-    state: present
   - name: Test Inventory - Smart
     organization: Default
     description: created by Ansible Playbook
-    state: present
     kind: smart
     host_filter:  "name__icontains=localhost"

--- a/playbooks/example_with_yaml/tower_configs/tower_notifications.yml
+++ b/playbooks/example_with_yaml/tower_configs/tower_notifications.yml
@@ -21,4 +21,3 @@ tower_notifications:
     port: 25
     username: '' # this is required even if there's no username
     password: '' # this is required even if there's no password
-

--- a/playbooks/example_with_yaml/tower_configs/tower_notifications.yml
+++ b/playbooks/example_with_yaml/tower_configs/tower_notifications.yml
@@ -21,4 +21,3 @@ tower_notifications:
     port: 25
     username: '' # this is required even if there's no username
     password: '' # this is required even if there's no password
-    state: present

--- a/playbooks/example_with_yaml/tower_configs/tower_organizations.yml
+++ b/playbooks/example_with_yaml/tower_configs/tower_organizations.yml
@@ -1,6 +1,4 @@
 ---
 tower_organizations:
   - name: Satellite
-    state: present # optional
   - name: Default
-    state: present

--- a/playbooks/example_with_yaml/tower_configs/tower_teams.yml
+++ b/playbooks/example_with_yaml/tower_configs/tower_teams.yml
@@ -2,7 +2,5 @@
 tower_teams:
   - name: satellite-qe
     organization: Satellite
-    state: present
   - name: satlab-admin
     organization: Satellite
-    state: present

--- a/playbooks/example_with_yaml/tower_configs/tower_templates.yml
+++ b/playbooks/example_with_yaml/tower_configs/tower_templates.yml
@@ -23,7 +23,6 @@ tower_templates:
     credentials: Demo Credential
     verbosity: 0
     inventory: localhost
-    state: present
 
 # You can retrieve a job along with its survey spec using tower cli as follows:
 # tower-cli receive --job_template <Name> --user admin --format yaml

--- a/roles/credential_types/README.md
+++ b/roles/credential_types/README.md
@@ -12,6 +12,7 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 ## Variables
 |Variable Name|Default Value|Required|Description|Example|
 |:---:|:---:|:---:|:---:|:---:|
+|`tower_state`|"present"|no|The state all objects will take unless overriden by object default|'absent'|
 |`tower_hostname`|""|yes|URL to the Ansible Tower Server.|127.0.0.1|
 |`tower_validate_certs`|`False`|no|Whether or not to validate the Ansible Tower Server's SSL certificate.||
 |`tower_config_file`|""|no|Path to the Tower or AWX config file.||

--- a/roles/credential_types/tasks/main.yml
+++ b/roles/credential_types/tasks/main.yml
@@ -8,7 +8,7 @@
     injectors:                      "{{ tower_credential_types_item.injectors | default(omit) | regex_replace('[ ]{2,}','') }}"
     inputs:                         "{{ tower_credential_types_item.inputs | default(omit) }}"
     kind:                           "{{ tower_credential_types_item.kind | default(omit) }}"
-    state:                          "{{ tower_credential_types_item.state | default('present') }}"
+    state:                          "{{ tower_credential_types_item.state | default(tower_state | default('present')) }}"
     tower_username:                 "{{ tower_username | default(omit) }}"
     tower_password:                 "{{ tower_password | default(omit) }}"
     tower_oauthtoken:               "{{ tower_oauthtoken | default(omit) }}"

--- a/roles/credentials/README.md
+++ b/roles/credentials/README.md
@@ -12,6 +12,7 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 ## Variables
 |Variable Name|Default Value|Required|Description|Example|
 |:---:|:---:|:---:|:---:|:---:|
+|`tower_state`|"present"|no|The state all objects will take unless overriden by object default|'absent'|
 |`tower_hostname`|""|yes|URL to the Ansible Tower Server.|127.0.0.1|
 |`tower_validate_certs`|`False`|no|Whether or not to validate the Ansible Tower Server's SSL certificate.||
 |`tower_config_file`|""|no|Path to the Tower or AWX config file.||

--- a/roles/credentials/tasks/main.yml
+++ b/roles/credentials/tasks/main.yml
@@ -11,7 +11,7 @@
     inputs:                         "{{ tower_credentials_item.inputs | default(omit) }}"
     user:                           "{{ tower_credentials_item.user | default(omit) }}"
     team:                           "{{ tower_credentials_item.team | default(omit) }}"
-    state:                          "{{ tower_credentials_item.state | default('present') }}"
+    state:                          "{{ tower_credentials_item.state | default(tower_state | default('present')) }}"
     tower_username:                 "{{ tower_username | default(omit) }}"
     tower_password:                 "{{ tower_password | default(omit) }}"
     tower_oauthtoken:               "{{ tower_oauthtoken | default(omit) }}"

--- a/roles/hosts/tasks/main.yml
+++ b/roles/hosts/tasks/main.yml
@@ -4,7 +4,7 @@
     name:             "{{ item.name }}"
     description:      "{{ item.description | default('created via Ansible Playbook') }}"
     inventory:        "{{ item.inventory }}"
-    state:            "{{ item.state | d('present') }}"
+    state:            "{{ item.state | default(tower_state | default('present')) }}"
     variables:        "{{ item.variables | d('') }}"
     tower_host:       "{{ tower_hostname }}"
     tower_username:   "{{ tower_username | default('admin') }}"

--- a/roles/inventories/README.md
+++ b/roles/inventories/README.md
@@ -5,6 +5,7 @@ An Ansible role to create inventories.
 ## Variables
 | Variable Name | Default Value | Required | Description | Type |
 |---|---|:---:|---|:---:|
+|`tower_state`|"present"|no|The state all objects will take unless overriden by object default|'absent'|
 |`tower_hostname`|""|yes|URL to the Ansible Tower Server.| string |
 |`validate_certs`|False|no|Whether or not to validate the Ansible Tower Server's SSL certificate.| boolean |
 |`tower_secrets`|False|yes|Whether or not to include variables stored in vars/tower-secrets.yml.  Set this value to `False` if you will be providing your sensitive values from elsewhere.| boolean |

--- a/roles/inventories/tasks/main.yml
+++ b/roles/inventories/tasks/main.yml
@@ -6,7 +6,7 @@
     kind:                 "{{ inventory.kind | default(omit) }}"
     name:                 "{{ inventory.name }}"  # REQUIRED
     organization:         "{{ inventory.organization | default('Default') }}"
-    state:                "{{ inventory.state | default('present') }}"
+    state:                "{{ inventory.state | default(tower_state | default('present')) }}"
     variables:            "{{ inventory.variables | default(omit) }}"
     tower_config_file:    "{{ tower_config_file | default(omit) }}"
     tower_host:           "{{ tower_hostname | default(omit) }}"

--- a/roles/inventory_sources/README.md
+++ b/roles/inventory_sources/README.md
@@ -5,6 +5,7 @@ An Ansible role to create inventory sources.
 ## Variables
 | Variable Name | Default Value | Required | Description | Type |
 |---|---|:---:|---|:---:|
+|`tower_state`|"present"|no|The state all objects will take unless overriden by object default|'absent'|
 |`tower_hostname`|""|yes|URL to the Ansible Tower Server.| string |
 |`tower_verify_ssl`|False|no|Whether or not to validate the Ansible Tower Server's SSL certificate.| boolean |
 |`tower_secrets`|False|yes|Whether or not to include variables stored in vars/tower-secrets.yml.  Set this value to `False` if you will be providing your sensitive values from elsewhere.| boolean |

--- a/roles/inventory_sources/tasks/main.yml
+++ b/roles/inventory_sources/tasks/main.yml
@@ -16,7 +16,7 @@
     source_regions:              "{{ source.source_regions | default(omit) }}"
     source_script:               "{{ source.source_script | default(omit) }}"
     source_vars:                 "{{ source.source_vars | default(omit) }}"
-    state:                       "{{ source.state | default('present') }}"
+    state:                       "{{ source.state | default(tower_state | default('present')) }}"
     timeout:                     "{{ source.timeout | default(omit) }}"
     update_cache_timeout:        "{{ source.update_cache_timeout | default(omit) }}"
     update_on_launch:            "{{ source.update_on_launch | default(omit) }}"

--- a/roles/job_templates/README.md
+++ b/roles/job_templates/README.md
@@ -10,6 +10,7 @@ Currently:
 ## Variables
 |Variable Name|Default Value|Required|Description|Example|
 |:---:|:---:|:---:|:---:|:---:|
+|`tower_state`|"present"|no|The state all objects will take unless overriden by object default|'absent'|
 |`tower_hostname`|""|yes|URL to the Ansible Tower Server.|127.0.0.1|
 |`validate_certs`|`False`|no|Whether or not to validate the Ansible Tower Server's SSL certificate.||
 |`tower_username`|""|yes|Admin User on the Ansible Tower Server.||

--- a/roles/job_templates/tasks/main.yml
+++ b/roles/job_templates/tasks/main.yml
@@ -44,7 +44,7 @@
     webhook_credential:             "{{ tower_templates_item.webhook_credential | default(omit) }}"
     scm_branch:                     "{{ tower_templates_item.scm_branch | default(omit) }}"
     labels:                         "{{ tower_templates_item.labels | default(omit) }}"
-    state:                          "{{ tower_templates_item.state | default('present') }}"
+    state:                          "{{ tower_templates_item.state | default(tower_state | default('present')) }}"
     notification_templates_started: "{{ tower_templates_item.notification_templates_started | default(omit) }}"
     notification_templates_success: "{{ tower_templates_item.notification_templates_success | default(omit) }}"
     notification_templates_error:   "{{ tower_templates_item.notification_templates_error | default(omit) }}"

--- a/roles/master_role_example/README.md
+++ b/roles/master_role_example/README.md
@@ -10,6 +10,7 @@ Currently:
 ## Variables
 |Variable Name|Default Value|Required|Description|Example|
 |:---:|:---:|:---:|:---:|:---:|
+|`tower_state`|"present"|no|The state all objects will take unless overriden by object default|'absent'|
 |`tower_hostname`|""|yes|URL to the Ansible Tower Server.|127.0.0.1|
 |`validate_certs`|`False`|no|Whether or not to validate the Ansible Tower Server's SSL certificate.||
 |`tower_username`|""|yes|Admin User on the Ansible Tower Server.||

--- a/roles/master_role_example/tasks/main.yml
+++ b/roles/master_role_example/tasks/main.yml
@@ -8,7 +8,7 @@
     description:                    "{{ ***********_item.description | default('') }}"
 
     # Role specific options
-
+    state:                          "{{ ***********_item.state | default(tower_state | default('present')) }}"
     tower_username:                 "{{ tower_username | default(omit) }}"
     tower_password:                 "{{ tower_password | default(omit) }}"
     tower_oauthtoken:               "{{ tower_oauthtoken | default(omit) }}"

--- a/roles/notifications/tasks/main.yml
+++ b/roles/notifications/tasks/main.yml
@@ -14,7 +14,7 @@
     recipients:            "{{ item.recipients | default(omit) }}"
     sender:                "{{ item.sender| default(omit) }}"
     server:                "{{ item.server| default(omit) }}"
-    state:                 "{{ item.state | default('present') }}"
+    state:                 "{{ item.state | default(tower_state | default('present')) }}"
     targets:               "{{ item.targets | default(omit) }}"
     use_ssl:               "{{ item.use_ssl | default('no') }}"
     use_tls:               "{{ item.use_tls | default('no')   }}"

--- a/roles/organizations/README.md
+++ b/roles/organizations/README.md
@@ -9,6 +9,7 @@ Currently:
 ## Variables
 |Variable Name|Default Value|Required|Description|Example|
 |:---:|:---:|:---:|:---:|:---:|
+|`tower_state`|"present"|no|The state all objects will take unless overriden by object default|'absent'|
 |`tower_hostname`|""|yes|URL to the Ansible Tower Server.|127.0.0.1|
 |`validate_certs`|`False`|no|Whether or not to validate the Ansible Tower Server's SSL certificate.||
 |`tower_username`|""|yes|Admin User on the Ansible Tower Server.||

--- a/roles/organizations/tasks/main.yml
+++ b/roles/organizations/tasks/main.yml
@@ -9,7 +9,7 @@
     notification_templates_success:     "{{ tower_organizations_item.notification_templates_success | default(omit) }}"
     notification_templates_error:       "{{ tower_organizations_item.notification_templates_error | default(omit) }}"
     notification_templates_approvals:   "{{ tower_organizations_item.notification_templates_approvals | default(omit) }}"
-    state:                              "{{ tower_organizations_item.state | default('present') }}"
+    state:                              "{{ tower_organizations_item.state | default(tower_state | default('present')) }}"
     tower_username:                     "{{ tower_username | default(omit) }}"
     tower_password:                     "{{ tower_password | default(omit) }}"
     tower_oauthtoken:                   "{{ tower_oauthtoken | default(omit) }}"

--- a/roles/projects/README.md
+++ b/roles/projects/README.md
@@ -9,6 +9,7 @@ Currently:
 ## Variables
 |Variable Name|Default Value|Required|Description|Example|
 |:---:|:---:|:---:|:---:|:---:|
+|`tower_state`|"present"|no|The state all objects will take unless overriden by object default|'absent'|
 |`tower_hostname`|""|yes|URL to the Ansible Tower Server.|127.0.0.1|
 |`validate_certs`|`False`|no|Whether or not to validate the Ansible Tower Server's SSL certificate.||
 |`tower_username`|""|yes|Admin User on the Ansible Tower Server.||

--- a/roles/projects/tasks/main.yml
+++ b/roles/projects/tasks/main.yml
@@ -18,7 +18,7 @@
     job_timeout:                    "{{ tower_projects_item.job_timeout | default(omit) }}"
     custom_virtualenv:              "{{ tower_projects_item.custom_virtualenv | default(omit) }}"
     organization:                   "{{ tower_projects_item.organization }}"
-    state:                          "{{ tower_projects_item.state | default('present') }}"
+    state:                          "{{ tower_projects_item.state | default(tower_state | default('present')) }}"
     wait:                           "{{ tower_projects_item.wait | default(omit) }}"
     notification_templates_started: "{{ tower_projects_item.notification_templates_started | default(omit) }}"
     notification_templates_success: "{{ tower_projects_item.notification_templates_success | default(omit) }}"

--- a/roles/schedules/README.md
+++ b/roles/schedules/README.md
@@ -10,6 +10,7 @@ Currently:
 ## Variables
 |Variable Name|Default Value|Required|Description|Example|
 |:---:|:---:|:---:|:---:|:---:|
+|`tower_state`|"present"|no|The state all objects will take unless overriden by object default|'absent'|
 |`tower_hostname`|""|yes|URL to the Ansible Tower Server.|127.0.0.1|
 |`validate_certs`|`False`|no|Whether or not to validate the Ansible Tower Server's SSL certificate.||
 |`tower_username`|""|yes|Admin User on the Ansible Tower Server.||

--- a/roles/schedules/tasks/main.yml
+++ b/roles/schedules/tasks/main.yml
@@ -18,7 +18,7 @@
     verbosity:                      "{{ schedule_item.verbosity | default(omit) }}"
     unified_job_template:           "{{ schedule_item.unified_job_template | default(omit) }}"
     enabled:                        "{{ schedule_item.enabled | default(omit) }}"
-    state:                          "{{ schedule_item.state | default('present') }}"
+    state:                          "{{ schedule_item.state | default(tower_state | default('present')) }}"
     tower_username:                 "{{ tower_username | default(omit) }}"
     tower_password:                 "{{ tower_password | default(omit) }}"
     tower_oauthtoken:               "{{ tower_oauthtoken | default(omit) }}"

--- a/roles/teams/README.md
+++ b/roles/teams/README.md
@@ -6,6 +6,7 @@ An Ansible Role to create Teams in Ansible Tower.
 ### Authentication
 |Variable Name|Default Value|Required|Description|Example|
 |:---:|:---:|:---:|:---:|:---:|
+|`tower_state`|"present"|no|The state all objects will take unless overriden by object default|'absent'|
 |`tower_hostname`|""|yes|URL to the Ansible Tower Server.|127.0.0.1|
 |`validate_certs`|`False`|no|Whether or not to validate the Ansible Tower Server's SSL certificate.||
 |`tower_username`|""|yes|Admin User on the Ansible Tower Server.||

--- a/roles/teams/tasks/main.yml
+++ b/roles/teams/tasks/main.yml
@@ -4,7 +4,7 @@
     description:         "{{ team.description | default(omit) }}"
     name:                "{{ team.name }}"
     organization:        "{{ team.organization }}"
-    state:               "{{ team.state | default(omit) }}"
+    state:               "{{ team.state | default(tower_state | default('present')) }}"
     tower_config_file:   "{{ team.tower_config_file | default(omit) }}"
     tower_host:          "{{ tower_hostname | default(omit) }}"
     tower_password:      "{{ tower_password | default(omit) }}"

--- a/roles/tower_role/README.md
+++ b/roles/tower_role/README.md
@@ -10,6 +10,7 @@ Currently:
 ## Variables
 |Variable Name|Default Value|Required|Description|Example|
 |:---:|:---:|:---:|:---:|:---:|
+|`tower_state`|"present"|no|The state all objects will take unless overriden by object default|'absent'|
 |`tower_hostname`|""|yes|URL to the Ansible Tower Server.|127.0.0.1|
 |`validate_certs`|`False`|no|Whether or not to validate the Ansible Tower Server's SSL certificate.||
 |`tower_username`|""|yes|Admin User on the Ansible Tower Server.||

--- a/roles/tower_role/tasks/main.yml
+++ b/roles/tower_role/tasks/main.yml
@@ -12,7 +12,7 @@
     credential:                     "{{ tower_rbac_item.credential | default(omit) }}"
     organization:                   "{{ tower_rbac_item.organization | default(omit) }}"
     project:                        "{{ tower_rbac_item.project | default(omit) }}"
-    state:                          "{{ tower_rbac_item.state | default('present') }}"
+    state:                          "{{ tower_rbac_item.state | default(tower_state | default('present')) }}"
     tower_username:                 "{{ tower_username | default(omit) }}"
     tower_password:                 "{{ tower_password | default(omit) }}"
     tower_oauthtoken:               "{{ tower_oauthtoken | default(omit) }}"

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -8,7 +8,7 @@
      first_name:          "{{ item.firstname | default(item.user) }}"
      last_name:           "{{ item.lastname | default(item.user) }}"
      superuser:           "{{ item.is_superuser | default('false') }}"
-     state:               "{{ item.state | default('present') }}"
+     state:               "{{ item.state | default(tower_state | default('present')) }}"
      tower_host:          "{{ tower_hostname }}"
      tower_username:      "{{ tower_username | default('admin') }}"
      tower_password:      "{{ tower_password }}"

--- a/roles/workflow_job_templates/README.md
+++ b/roles/workflow_job_templates/README.md
@@ -10,6 +10,7 @@ Required Collections:
 ## Variables
 |Variable Name|Default Value|Required|Description|Example|
 |:---:|:---:|:---:|:---:|:---:|
+|`tower_state`|"present"|no|The state all objects will take unless overriden by object default|'absent'|
 |`tower_host`|""|yes|URL to the Ansible Tower Server.|127.0.0.1|
 |`tower_verify_ssl`|`False`|no|Whether or not to validate the Ansible Tower Server's SSL certificate.||
 |`tower_username`|""|yes|Admin User on the Ansible Tower Server.||

--- a/roles/workflow_job_templates/tasks/add_workflows_schema.yml
+++ b/roles/workflow_job_templates/tasks/add_workflows_schema.yml
@@ -4,7 +4,7 @@
     identifier :                    "{{ workflow_loop_node.identifier }}"   # internal identification ID
     unified_job_template :          "{{ workflow_loop_node.unified_job_template.name }}"  # Run Job template
     workflow :                      "{{ workflow_loop_var.name }}"        # Workflow job template name to associate with
-    state:                          "{{ workflow_loop_node.state | default('present') }}"
+    state:                          "{{ workflow_loop_node.state | default(tower_state | default('present')) }}"
     all_parents_must_converge :     "{{ workflow_loop_node.all_parents_must_converge | default (omit) }}"
     organization:                   "{{ workflow_loop_var.organization.name }}" # Workflow job template organization
     tower_username:                 "{{ tower_username | default(omit) }}"
@@ -26,7 +26,7 @@
     always_nodes:                   "{{ workflow_loop_node.related.always_nodes  | json_query('[*].identifier') | default (omit) }}" # Nodes to advance on always (blue links) # noqa 204
     success_nodes:                  "{{ workflow_loop_node.related.success_nodes | json_query('[*].identifier') | default (omit) }}" # Nodes to advance on success (green links) # noqa 204
     failure_nodes:                  "{{ workflow_loop_node.related.failure_nodes | json_query('[*].identifier') | default (omit) }}" # Nodes to advance on failure (red links) # noqa 204
-    state:                          "{{ workflow_loop_node.state | default('present') }}"
+    state:                          "{{ workflow_loop_node.state | default(tower_state | default('present')) }}"
     organization:                   "{{ workflow_loop_var.organization.name }}"
     tower_username:                 "{{ tower_username | default(omit) }}"
     tower_password:                 "{{ tower_password | default(omit) }}"

--- a/roles/workflow_job_templates/tasks/main.yml
+++ b/roles/workflow_job_templates/tasks/main.yml
@@ -15,7 +15,7 @@
     ask_limit_on_launch:                "{{ workflow_loop_var.ask_limit_on_launch | default(omit) }}"
     survey_enabled:                     "{{ workflow_loop_var.survey_enabled }}"
     survey:                             "{{ workflow_loop_var.related.survey_spec | to_json }}"
-    state:                              "{{ workflow_loop_var.state | default('present') }}"
+    state:                              "{{ workflow_loop_var.state | default(tower_state | default('present')) }}"
     notification_templates_started:     "{{ workflow_loop_var.related.notification_templates_started.name | default(omit) }}"
     notification_templates_success:     "{{ workflow_loop_var.related.notification_templates_success.name | default(omit) }}"
     notification_templates_error:       "{{ workflow_loop_var.related.notification_templates_error.name | default(omit) }}"


### PR DESCRIPTION
_This PR can be closed if people disagree it should exist..._ 

I think its pretty handy to have an overall default to set to delete items. This wouldnt cause breaking changes as default will still be set as 'present' for all items unless `tower_state` is set, in which case it will default to that (unless set in the object itself).

**Use Case**
For testing purposes being able to test creation from fresh by creating/deleting easily by changing 1 var instead of many.

```sh
ansible-playbook playbooks/example_with_yaml/configure_tower.yml -e tower_state=absent
```