### PR TITLE
Fixing vars for hosts role to omit if not present, throws error otherwise

### DIFF
--- a/roles/hosts/tasks/main.yml
+++ b/roles/hosts/tasks/main.yml
@@ -5,7 +5,7 @@
     description:      "{{ item.description | default('created via Ansible Playbook') }}"
     inventory:        "{{ item.inventory }}"
     state:            "{{ item.state | default(tower_state | default('present')) }}"
-    variables:        "{{ item.variables | d('') }}"
+    variables:        "{{ item.variables | default(omit) }}"
     tower_host:       "{{ tower_hostname }}"
     tower_username:   "{{ tower_username | default('admin') }}"
     tower_password:   "{{ tower_password }}"


### PR DESCRIPTION
## Purpose
The `hosts` role had default set to `''` for variables, but that is causing error. So let's set it to `omit` if not passed explicitly. I tested with `omit` and it works fine.